### PR TITLE
Archive project in favor of Changesets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,77 @@
 # changelogger
 
-Manage your JS/TS changelog conflict free
+> ⚠️ **Archived / no longer maintained.** This project has been superseded by
+> [**Changesets**](https://github.com/changesets/changesets), which solves the
+> same problem (conflict-free changelogs) and has become the de-facto standard.
+> **Please use Changesets instead.** See [Why this is archived](#why-this-is-archived).
 
-## Test run
+A small CLI experiment for managing a JS/TS `CHANGELOG.md` without merge
+conflicts. Each change was written to its own file in a `changes/` directory and
+merged into the changelog at release time, so contributors never edited the same
+file at the same time.
 
-For now you can run the following commands to test the library:
+## Why this is archived
+
+The idea here — one file per change, merged at release — is sound, but it is now
+implemented far more completely by [Changesets](https://github.com/changesets/changesets):
+
+- One markdown file per change in a `.changeset/` folder (no merge conflicts).
+- Automatic [SemVer](https://semver.org/) bump detection (patch/minor/major).
+- First-class **monorepo** support with linked/dependent package bumps.
+- Automated publishing via the
+  [Changesets GitHub Action](https://github.com/changesets/action).
+- A large, active community and ecosystem.
+
+Rather than maintain an overlapping tool, this repository is kept read-only for
+reference only. It is **not published to npm** and receives no updates.
+
+## Use Changesets instead
 
 ```bash
-node --experimental-specifier-resolution=node bin/index.js
+npm install --save-dev @changesets/cli
+npx changeset init
 ```
 
-## Commands
+Then, for each change:
 
-### List
-  
-  ```bash
-  node --experimental-specifier-resolution=node bin/index.js list
-  ```
+```bash
+npx changeset        # describe the change + pick a version bump
+```
 
-  List all changes in the changelog
+And at release time:
 
-### Add
+```bash
+npx changeset version   # consume changesets, update versions + CHANGELOG.md
+npx changeset publish   # publish to npm
+```
 
-  ```bash
-  node --experimental-specifier-resolution=node bin/index.js add
-  ```
+Full docs: <https://github.com/changesets/changesets>.
 
-  Create a new temporary changelog entry in a new file using a dialog interface
+### Other tools worth a look
 
-### Merge
+- [`changesets`](https://github.com/changesets/changesets) — recommended; per-change files, great for monorepos.
+- [`release-please`](https://github.com/googleapis/release-please) — automated releases driven by Conventional Commits.
+- [`semantic-release`](https://github.com/semantic-release/semantic-release) — fully automated, commit-driven versioning and publishing.
+- [`conventional-changelog`](https://github.com/conventional-changelog/conventional-changelog) — generate a changelog from your commit history.
 
-  ```bash
-  node --experimental-specifier-resolution=node bin/index.js merge
-  ```
+## What it did (for reference)
 
-  Merge all temporary changelog entries into the changelog.md file. Use this command after you have finished adding all changes during a release.
+The CLI offered four commands, built on `commander` + `inquirer`:
+
+| Command | Alias | Description |
+| --- | --- | --- |
+| `initiate` | `i` | Create a new `CHANGELOG.md` scaffold. |
+| `add` | `a` | Add a change as a new file in `changes/` via a prompt. |
+| `list` | `ls` | Print the current `CHANGELOG.md`. |
+| `merge` | `m` | Fold `changes/` entries into `CHANGELOG.md` under a version. |
+
+The changelog format followed
+[Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+> **Note:** this was a pre-release prototype and was never fully working — see the
+> commit history and the original review notes. Treat the code as a reference, not
+> a working tool.
+
+## License
+
+[MIT](./LICENSE) © CroCode BV

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@crocode/changelogger",
   "version": "0.0.1",
-  "description": "Manage your JS/TS changelog conflict free",
+  "description": "[ARCHIVED] Superseded by Changesets (https://github.com/changesets/changesets). Manage your JS/TS changelog conflict free.",
+  "private": true,
   "type": "module",
   "files": [
     "!lib/__tests__/**/*",


### PR DESCRIPTION
## Summary

This project is superseded by [Changesets](https://github.com/changesets/changesets), which solves the same problem (conflict-free changelogs via one-file-per-change) far more completely and has become the de-facto standard. Rather than revive an overlapping, never-fully-working prototype, this PR archives it and points users to the modern alternative.

## Changes

- **`README.md`** — rewritten as a modern, archival README:
  - Prominent "Archived / no longer maintained" banner pointing to Changesets.
  - "Why this is archived" section explaining the overlap.
  - Changesets quick-start, plus alternatives (release-please, semantic-release, conventional-changelog).
  - For-reference command table describing what the CLI did.
- **`package.json`** — added `"private": true` to prevent accidental npm publishing, and prefixed the description with `[ARCHIVED]`.

## Follow-up (manual)

After merging, flip the GitHub **Settings → Danger zone → Archive this repository** toggle to make the repo read-only (no API tool available for that).

https://claude.ai/code/session_01TA3skidRnyfWkRHZcUQey8

---
_Generated by [Claude Code](https://claude.ai/code/session_01TA3skidRnyfWkRHZcUQey8)_